### PR TITLE
fix error in QuestionChoiceAPI-PUT

### DIFF
--- a/services/quiz/controllers/QuestionChoicesController.py
+++ b/services/quiz/controllers/QuestionChoicesController.py
@@ -79,7 +79,7 @@ class QuestionChoiceAPI(Resource):
         # operations
         try:
             questionChoice = questionChoiceUpdateOperation(
-                qc['question_id'], qc['questionChoice_id'], qc['col'], qc['value']
+                qc['question_id'], qc['questionChoice_id'], qc['description'], qc['is_correct']
             )
         except ErrorWithCode as e:
             return make_response(

--- a/services/quiz/operations/questionChoices_operations.py
+++ b/services/quiz/operations/questionChoices_operations.py
@@ -38,17 +38,18 @@ def questionChoiceCreateOperation(question_id, description, is_correct):
     # success case
     return questionChoice
     
-def questionChoiceUpdateOperation(question_id, questionChoice_id, col, value):
+def questionChoiceUpdateOperation(question_id, questionChoice_id, description, is_correct):
     questionChoice = questionChoiceRead(question_id, questionChoice_id)
 
     # questionChoice is not found
     if questionChoice is None:
         raise ErrorWithCode(404, "No questionChoice found")
 
-    if col == 'description':
-        questionChoice.description = value
-    elif col == 'is_correct':
-        questionChoice.is_correct = value
+    if description is not None:
+        questionChoice.description = description
+
+    if is_correct is not None:
+        questionChoice.is_correct = is_correct
 
     if questionChoiceUpdate() == False:
         raise ErrorWithCode(400, "Unsuccessful")


### PR DESCRIPTION
@phangjunyu main issue lies in not updating postman after the previous patch was done

request should be
`/question_choices/?question_id=XXX&questionChoice_id=XXX&description=XXX&is_correct=XXX`

where `description` and `is_correct` is optional (can choose to update any number of attributes concurrently)